### PR TITLE
Feature: Add strong_parameters class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The following example demonstrates a user signup form-object and how this would 
 * Points of interest:
  * The use of the `before_validation` callback hook.
  * The use of the NestedValidator to run any existing validations defined on the `User` model.
+ * The use of the [strong_parameters](#strong-parameters) method on the form object instead of defining it in the controller
 
 #### user_signup.rb:
 ```ruby
@@ -51,7 +52,6 @@ require 'active_model'
 class UserSignup
   include ActiveModel::FormObject
 
-  attr_accessor :name
   attr_reader :user
 
   validates :name, :length => { :minimum => 5 }
@@ -59,10 +59,12 @@ class UserSignup
 
   before_validation :create_user
 
+  strong_parameters :user => [:name]
+
   private
 
   def create_user
-    @user = User.new(:name => name)
+    @user = User.new(user_params)
   end
 
   def persist!
@@ -81,7 +83,7 @@ class UsersController < ApplicationController
   end
 
   def create
-    @signup_form = UserSignup.new(params[:user])
+    @signup_form = UserSignup.new(:params => params)
     if @signup_form.save()
       @user = @signup_form.user
       respond_with @user
@@ -102,6 +104,61 @@ end
   <%= f.submit "Submit" %>
 <% end %>
 ```
+
+## Strong Parameters
+
+In rails 4 the [strong_parameters](https://github.com/rails/strong_parameters) gem is used as a method of protecting the attributes that can be passed through in the creation of a model. The usual way of doing this is defining a method on your controller:
+
+```ruby
+
+class UsersController < ApplicationController
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
+
+end
+
+```
+
+With The `ActiveModel::FormObject::StrongParameters` module this can now be defined in your form object using the `strong_parameters` class method. The following is the Form Object version of the `user_params` method above:
+
+```ruby
+
+  class UserRegister
+    include ActiveModel::FormObject
+
+    strong_paramters :user => [:name, :email]
+  end
+
+```
+
+The default implementation assumes a `params` method on the FormObject which can be defined in the controller as:
+
+```ruby
+
+  UserRegister.new(:params => params)
+
+```
+
+If you wish to change the name of the params method to something else such as `my_params` then the `strong_paramters` method can be called with `:my_params` as an argument:
+
+```ruby
+
+    strong_paramters, :my_params, :user => [:name, :email]
+
+```
+
+In your controller you can now do:
+
+```ruby
+
+  UserRegister.new(:my_params => params)
+
+```
+
 
 ## Contributing
 

--- a/lib/active_model/form_object.rb
+++ b/lib/active_model/form_object.rb
@@ -2,6 +2,7 @@ module ActiveModel
   module FormObject
     require_relative "form_object/railtie" if defined?(Rails)
     require_relative 'form_object/validators/nested_validator'
+    require_relative 'form_object/strong_parameters'
 
     def self.included klass
       klass.class_eval do
@@ -10,6 +11,7 @@ module ActiveModel
         include Validations
         include Validations::Callbacks
         include Validators
+        include StrongParameters
         extend ClassMethods
         include InstanceMethods
       end

--- a/lib/active_model/form_object/strong_parameters.rb
+++ b/lib/active_model/form_object/strong_parameters.rb
@@ -1,0 +1,43 @@
+module ActiveModel
+  module FormObject
+    module StrongParameters
+
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def strong_parameters(parameter_name, opts = {})
+          if opts == {}
+            opts = parameter_name
+            parameter_name = :params
+          end
+
+          StrongParameters.new(self).set(parameter_name, opts)
+        end
+      end
+
+      class StrongParameters
+        attr_accessor :klass
+
+        def initialize(klass)
+          @klass = klass
+        end
+
+        def set(parameter_name, opts)
+          opts.each do |key, value|
+            klass.send(:define_method, "#{key}_params".to_sym) do
+              params = self.send(parameter_name)
+              unless params[key].nil?
+                self.send(parameter_name).require(key).permit(value)
+              end
+            end
+          end
+
+        end
+      end
+
+    end
+  end
+end
+

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -6,8 +6,8 @@ class UsersController < ApplicationController
   end
 
   def create
-    @signup_form = UserSignup.new(params[:user])
-    if @signup_form.save()
+    @signup_form = UserSignup.new(:params => params)
+    if @signup_form.save
       @user = @signup_form.user
       respond_with @user
     else

--- a/spec/dummy/app/form_objects/user_signup.rb
+++ b/spec/dummy/app/form_objects/user_signup.rb
@@ -11,10 +11,13 @@ class UserSignup
 
   before_validation :create_user
 
+  strong_parameters :user => [:name]
+
   private
 
   def create_user
-    @user = User.new(:name => name)
+    @user = User.new(user_params)
+    @name = user_params[:name]
   end
 
   def persist!

--- a/spec/lib/strong_parameters_spec.rb
+++ b/spec/lib/strong_parameters_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'active_model/form_object/strong_parameters'
+
+describe "ActiveModel::FormObject::StrongParameters" do
+
+  class StrongParametersTester
+    include ActiveModel::FormObject::StrongParameters
+
+    strong_parameters :user => [:name, :email]
+  end
+
+  describe "class methods" do
+    it "adds the #strong_parameters method" do
+      expect(StrongParametersTester.respond_to?(:strong_parameters)).to eql(true)
+    end
+  end
+
+  describe "instance methods" do
+    it "adds the :key_params instance method" do
+      expect(StrongParametersTester.new.respond_to?(:user_params)).to eql(true)
+    end
+  end
+
+  describe ActiveModel::FormObject::StrongParameters::StrongParameters do
+
+    describe "#initialize" do
+
+      it "sets its klass to a class" do
+        klass = StrongParametersTester
+        expect(described_class.new(klass).klass).to eql(klass)
+      end
+
+    end
+
+    describe "#set" do
+
+      class StrongParametersClassTester
+
+        attr_accessor :required, :permitted
+
+        def [](key)
+          true
+        end
+
+        def my_params
+          return self
+        end
+
+        def require(args)
+          @required = args
+          return self
+        end
+
+        def permit(args)
+          @permitted = args
+          return self
+        end
+      end
+
+      before(:each) do
+        strong_params = described_class.new(StrongParametersClassTester)
+        strong_params.set(:my_params, {:admin => [:email, :name] })
+      end
+
+      it "defines a method on the defined class" do
+        expect(StrongParametersClassTester.new.respond_to?(:admin_params)).to eql(true)
+      end
+
+      it "calls the method which calls #require and #permit on the parameter name" do
+        tester = StrongParametersClassTester.new
+        tester.admin_params
+        expect(tester.required).to eql(:admin)
+        expect(tester.permitted).to eql([:email, :name])
+      end
+
+      it "doesn't call the method when the parameter is missing" do
+        tester = StrongParametersClassTester.new
+        allow(tester).to receive(:[]).and_return(nil)
+        tester.admin_params
+        expect(tester.required).to eql(nil)
+        expect(tester.permitted).to eql(nil)
+      end
+
+    end
+  end
+
+end


### PR DESCRIPTION
In rails 4 the strong_parameters gem is used as a method of protecting the
attributes that can be passed through in the creation of a model. The usual
way of doing this is defining a method on your controller however this is not
the preferred location for defining the strong_parameters when using
form_objects. To prevent having to define a boilerplate `x_params` method on
every form object a `strong_parameters` class method has been added.
