### PR TITLE
fix(generator): create/destroy shared examples when required

### DIFF
--- a/lib/active_model/form_object/generators/rspec/form_object_generator.rb
+++ b/lib/active_model/form_object/generators/rspec/form_object_generator.rb
@@ -8,11 +8,27 @@ module Rspec
       source_root File.expand_path('../templates', __FILE__)
 
       def copy_shared_example
-        template "shared_example.rb",
-          File.join(support_dir_path, "form_object.rb")
+        case self.behavior
+        when :invoke
+          template 'shared_example.rb', shared_example_path if shared_example_not_created?
+        when :revoke
+          template 'shared_example.rb', shared_example_path if last_active_model_form_object?
+        end
       end
 
       private
+
+      def shared_example_path
+        File.join(support_dir_path, "form_object.rb")
+      end
+
+      def last_active_model_form_object?
+        Dir[File.join('app/form_objects', '**', '*')].count { |file| File.file?(file) } < 2
+      end
+
+      def shared_example_not_created?
+        !File.exist?(shared_example_path)
+      end
 
       def template_name
         'form_object_spec.rb'


### PR DESCRIPTION
Previously, the generator was greedy
(https://github.com/mattfreer/active_model_form_objects/issues/3),
however, now the generator only creates the shared example specs if
there are none and destroys them if it is destroying the last active
model form object.

The method hooks into the behavior on the class and performs a task when
it is set to `invoke` or `revoke`
(http://factore.ca/blog/126-reversible-rails-generators).