### PR TITLE
chore(travis): upgrade ruby version to 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.2.2
 before_script:
   cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
 


### PR DESCRIPTION
Travis builds were failing with the following error:

``` bash
Gem::InstallError: rack requires Ruby version >= 2.2.2.
```

Travis config has been updated to use Ruby version 2.2.2
